### PR TITLE
Mark round_up_to_next as inline

### DIFF
--- a/src/libstd/collections/hash/table.rs
+++ b/src/libstd/collections/hash/table.rs
@@ -511,6 +511,7 @@ impl<K, V, M: Deref<Target=RawTable<K, V>>> GapThenFull<K, V, M> {
 /// # Panics
 ///
 /// Panics if `target_alignment` is not a power of two.
+#[inline]
 fn round_up_to_next(unrounded: usize, target_alignment: usize) -> usize {
     assert!(target_alignment.is_power_of_two());
     (unrounded + target_alignment - 1) & !(target_alignment - 1)


### PR DESCRIPTION
This speeds up rustc on #25916 from 1.36±0.022s to 1.326±0.025s

Tests pass locally (even on 32-bit :-)

r? @Gankro
